### PR TITLE
Fix NSSetUncaughtExceptionHandler usage with closure

### DIFF
--- a/iOS/Debugger/Core/DebuggerEngine.swift
+++ b/iOS/Debugger/Core/DebuggerEngine.swift
@@ -291,8 +291,10 @@ public final class DebuggerEngine {
     // MARK: - Private Methods
 
     private func setupExceptionHandling() {
-        // Set up exception handling with a static function to avoid capturing self
-        NSSetUncaughtExceptionHandler(DebuggerEngine.handleUncaughtException)
+        // Set up exception handling with a closure that calls our static method
+        NSSetUncaughtExceptionHandler({ exception in
+            DebuggerEngine.handleUncaughtException(exception)
+        })
     }
     
     // Static exception handler that doesn't capture self


### PR DESCRIPTION
This PR fixes the compiler error in DebuggerEngine.swift by replacing the direct method reference with a closure when calling NSSetUncaughtExceptionHandler.

The error was:
```
a C function pointer can only be formed from a reference to a func or a literal closure
```

The fix uses a closure that calls our static method, which satisfies Swift requirements for C function pointers.