### PR TITLE
Fix closure capturing memoryObserver before declaration

### DIFF
--- a/iOS/Operations/CoreML/CoreMLManager.swift
+++ b/iOS/Operations/CoreML/CoreMLManager.swift
@@ -422,8 +422,9 @@ final class CoreMLManager {
             }
         }
 
-        // Store the observer in a local variable first
-        let memoryObserver = NotificationCenter.default.addObserver(
+        // Create the observer without capturing itself
+        var memoryObserver: NSObjectProtocol?
+        memoryObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,
             object: nil,
             queue: .main
@@ -438,14 +439,18 @@ final class CoreMLManager {
             }
 
             // Remove the observer itself
-            NotificationCenter.default.removeObserver(memoryObserver)
+            if let observer = memoryObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
 
             self?.isModelLoading = false
             completion?(false)
         }
 
         // Store the observer in the array for later cleanup
-        memoryObservers.append(memoryObserver)
+        if let observer = memoryObserver {
+            memoryObservers.append(observer)
+        }
 
         // Perform actual loading in background
         predictionQueue.async { [weak self] in


### PR DESCRIPTION
This PR fixes the compiler error in CoreMLManager.swift where the closure was capturing the memoryObserver variable before it was declared.

The error was:
```
closure captures memoryObserver before it is declared
```

Changes made:
1. Declared memoryObserver as an optional variable before assigning it
2. Used optional binding when referencing it inside the closure
3. Used optional binding when adding it to the memoryObservers array

This ensures the variable is properly declared before being referenced in the closure.