### PR TITLE
Fix Swift compilation errors

### DIFF
--- a/iOS/Delegates/AppDelegate+PhasedInitialization.swift
+++ b/iOS/Delegates/AppDelegate+PhasedInitialization.swift
@@ -120,17 +120,16 @@ extension AppDelegate {
         
         // Ensure UI is responsive regardless of initialization state
         DispatchQueue.main.async {
-                // Use UIWindowScene.windows on iOS 15+ instead of deprecated UIApplication.shared.windows
-                if #available(iOS 15.0, *) {
-                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                       let rootVC = windowScene.windows.first?.rootViewController {
-                        rootVC.view.isUserInteractionEnabled = true
-                    }
-                } else {
-                    // Fallback for older iOS versions
-                    if let rootVC = UIApplication.shared.windows.first?.rootViewController {
-                        rootVC.view.isUserInteractionEnabled = true
-                    }
+            // Use UIWindowScene.windows on iOS 15+ instead of deprecated UIApplication.shared.windows
+            if #available(iOS 15.0, *) {
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let rootVC = windowScene.windows.first?.rootViewController {
+                    rootVC.view.isUserInteractionEnabled = true
+                }
+            } else {
+                // Fallback for older iOS versions
+                if let rootVC = UIApplication.shared.windows.first?.rootViewController {
+                    rootVC.view.isUserInteractionEnabled = true
                 }
             }
         }

--- a/iOS/Extensions/CALayer+Shadow.swift
+++ b/iOS/Extensions/CALayer+Shadow.swift
@@ -1,15 +1,6 @@
 import UIKit
 
 extension CALayer {
-    /// Apply a blue tinted shadow effect to the layer
-    func applyBlueTintedShadow() {
-        masksToBounds = false
-        shadowColor = UIColor.systemBlue.cgColor
-        shadowOffset = CGSize(width: 0, height: 4)
-        shadowOpacity = 0.2
-        shadowRadius = 8
-    }
-    
     /// Apply a futuristic shadow effect to the layer
     func applyFuturisticShadow() {
         masksToBounds = false


### PR DESCRIPTION
This PR fixes the following Swift compilation errors:

1. Fixed extraneous closing brace in AppDelegate+PhasedInitialization.swift
2. Fixed indentation in initializeComponentsWithCrashProtection method
3. Removed duplicate applyBlueTintedShadow method from CALayer+Shadow.swift to resolve redeclaration error

These changes resolve the following errors:
- /Users/runner/work/Code-test/Code-test/iOS/Delegates/AppDelegate+PhasedInitialization.swift:167:1: extraneous '}' at top level
- /Users/runner/work/Code-test/Code-test/iOS/Delegates/AppDelegate+PhasedInitialization.swift:107:21: value of type 'AppDelegate' has no member 'shouldProceedWithMemoryCheck'
- /Users/runner/work/Code-test/Code-test/iOS/Extensions/CALayer+Shadow.swift:5:10: invalid redeclaration of 'applyBlueTintedShadow()'

All files now compile without errors.
